### PR TITLE
Added support for Nuke 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,137 @@ jobs:
           minor: 2
           patch: 5
           url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v5/Nuke13.2v5-linux-x86_64.tgz'
-          extra_build_args: --tag natescarlet/nuke:latest --tag natescarlet/nuke:13 --tag natescarlet/nuke:13.2
+  publish-13-2-6:
+    executor: docker
+    steps:
+      - publish:
+          major: 13
+          minor: 2
+          patch: 6
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v6/Nuke13.2v6-linux-x86_64.tgz'
+  publish-13-2-7:
+    executor: docker
+    steps:
+      - publish:
+          major: 13
+          minor: 2
+          patch: 7
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v7/Nuke13.2v7-linux-x86_64.tgz'
+  publish-13-2-8:
+    executor: docker
+    steps:
+      - publish:
+          major: 13
+          minor: 2
+          patch: 8
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v8/Nuke13.2v8-linux-x86_64.tgz'
+  publish-13-2-9:
+    executor: docker
+    steps:
+      - publish:
+          major: 13
+          minor: 2
+          patch: 9
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v9/Nuke13.2v9-linux-x86_64.tgz'
+          extra_build_args: --tag natescarlet/nuke:13 --tag natescarlet/nuke:13.2
+  publish-14-0-1:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 1
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v1/Nuke14.0v1-linux-x86_64.tgz'
+  publish-14-0-2:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 2
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v2/Nuke14.0v2-linux-x86_64.tgz'
+  publish-14-0-3:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 3
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v3/Nuke14.0v3-linux-x86_64.tgz'
+  publish-14-0-4:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 4
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v4/Nuke14.0v4-linux-x86_64.tgz'
+  publish-14-0-5:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 5
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v5/Nuke14.0v5-linux-x86_64.tgz'
+  publish-14-0-6:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 6
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v6/Nuke14.0v6-linux-x86_64.tgz'
+  publish-14-0-7:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 0
+          patch: 7
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v7/Nuke14.0v7-linux-x86_64.tgz'
+          extra_build_args: --tag natescarlet/nuke:14.0
+  publish-14-1-1:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 1
+          patch: 1
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v1/Nuke14.1v1-linux-x86_64.tgz'
+  publish-14-1-2:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 1
+          patch: 2
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v2/Nuke14.1v2-linux-x86_64.tgz'
+  publish-14-1-3:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 1
+          patch: 3
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v3/Nuke14.1v3-linux-x86_64.tgz'
+  publish-14-1-4:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 1
+          patch: 4
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v4/Nuke14.1v4-linux-x86_64.tgz'
+  publish-14-1-5:
+    executor: docker
+    steps:
+      - publish:
+          major: 14
+          minor: 1
+          patch: 5
+          url: 'https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v5/Nuke14.1v5-linux-x86_64.tgz'
+          extra_build_args: --tag natescarlet/nuke:latest --tag natescarlet/nuke:14 --tag natescarlet/nuke:14.1
 workflows:
   version: 2
   build and publish:
@@ -963,6 +1093,86 @@ workflows:
               only:
                 - master
       - publish-13-2-5:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-13-2-6:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-13-2-7:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-13-2-8:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-13-2-9:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-1:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-2:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-3:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-4:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-5:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-6:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-0-7:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-1-1:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-1-2:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-1-3:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-1-4:
+          filters:
+            branches:
+              only:
+                - master
+      - publish-14-1-5:
           filters:
             branches:
               only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM centos:7 AS install
 # Example: https://mirrors.aliyun.com/pypi/simple
 ARG PIP_INDEX_URL
 RUN set -ex ;\
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/^# baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/*.repo; \
     yum -y install \
         # nuke common requires
         xorg-x11-server-Xvfb \
@@ -32,6 +38,11 @@ ENV NUKE_PATCH=${NUKE_PATCH}
 ENV NUKE_VERSION=${NUKE_MAJOR}.${NUKE_MINOR}v${NUKE_PATCH}
 
 RUN set -ex ;\
+    if [ "${NUKE_MAJOR}" == 14 ]; then \
+        yum -y install \
+            libXv \
+        ;\
+    fi; \
     if [ "${NUKE_MAJOR}" == 13 ]; then \
         yum -y install \
             libXv \
@@ -70,8 +81,8 @@ RUN set -ex ;\
     rm -rf /var/cache ;
 
 WORKDIR /usr/local/Nuke${NUKE_VERSION}
-ARG NUKE_DOWNLOAD_URL=https://thefoundry.s3.amazonaws.com/products/nuke/releases/${NUKE_VERSION}/Nuke${NUKE_VERSION}-linux-x86-release-64.tgz
-ARG NUKE_FILE_EXCLUDE="Documentation plugins/OCIOConfigs/configs/aces_* plugins/caravr plugins/air libtorch* libcudnn* libcublas* libcusparse* libcusolver* libmkl*"
+ARG NUKE_DOWNLOAD_URL=https://thefoundry.s3.amazonaws.com/products/nuke/releases/${NUKE_VERSION}/Nuke${NUKE_VERSION}-linux-x86_64.tgz
+ARG NUKE_FILE_EXCLUDE="Documentation plugins/OCIOConfigs/configs/aces_* plugins/caravr plugins/air libtorch* libcudnn* libcublas* libcusparse* libcusolver*"
 RUN set -ex ;\
     mkdir -p /tmp/Nuke/ ;\
     curl -o /tmp/Nuke/Nuke${NUKE_VERSION}.tgz $(echo ${NUKE_DOWNLOAD_URL} | envsubst) ;\

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ tags:
 
 <!-- image badges start -->
 
+![14.1v5](https://img.shields.io/docker/image-size/natescarlet/nuke/14.1v5?label=14.1v5)
+![14.1v4](https://img.shields.io/docker/image-size/natescarlet/nuke/14.1v4?label=14.1v4)
+![14.1v3](https://img.shields.io/docker/image-size/natescarlet/nuke/14.1v3?label=14.1v3)
+![14.1v2](https://img.shields.io/docker/image-size/natescarlet/nuke/14.1v2?label=14.1v2)
+![14.1v1](https://img.shields.io/docker/image-size/natescarlet/nuke/14.1v1?label=14.1v1)
+
+![14.0v7](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v7?label=14.0v7)
+![14.0v6](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v6?label=14.0v6)
+![14.0v5](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v5?label=14.0v5)
+![14.0v4](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v4?label=14.0v4)
+![14.0v3](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v3?label=14.0v3)
+![14.0v2](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v2?label=14.0v2)
+![14.0v1](https://img.shields.io/docker/image-size/natescarlet/nuke/14.0v1?label=14.0v1)
+
+![13.2v9](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v9?label=13.2v9)
+![13.2v8](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v8?label=13.2v8)
+![13.2v7](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v7?label=13.2v7)
+![13.2v6](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v6?label=13.2v6)
 ![13.2v5](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v5?label=13.2v5)
 ![13.2v4](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v4?label=13.2v4)
 ![13.2v3](https://img.shields.io/docker/image-size/natescarlet/nuke/13.2v3?label=13.2v3)

--- a/versions.json
+++ b/versions.json
@@ -280,6 +280,70 @@
     {
       "version": [13, 2, 5],
       "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v5/Nuke13.2v5-linux-x86_64.tgz"
+    },
+    {
+      "version": [13, 2, 6],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v6/Nuke13.2v6-linux-x86_64.tgz"
+    },
+    {
+      "version": [13, 2, 7],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v7/Nuke13.2v7-linux-x86_64.tgz"
+    },
+    {
+      "version": [13, 2, 8],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v8/Nuke13.2v8-linux-x86_64.tgz"
+    },
+    {
+      "version": [13, 2, 9],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/13.2v9/Nuke13.2v9-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 1],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v1/Nuke14.0v1-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 2],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v2/Nuke14.0v2-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 3],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v3/Nuke14.0v3-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 4],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v4/Nuke14.0v4-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 5],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v5/Nuke14.0v5-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 6],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v6/Nuke14.0v6-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 0, 7],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.0v7/Nuke14.0v7-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 1, 1],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v1/Nuke14.1v1-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 1, 2],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v2/Nuke14.1v2-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 1, 3],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v3/Nuke14.1v3-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 1, 4],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v4/Nuke14.1v4-linux-x86_64.tgz"
+    },
+    {
+      "version": [14, 1, 5],
+      "url": "https://thefoundry.s3.amazonaws.com/products/nuke/releases/14.1v5/Nuke14.1v5-linux-x86_64.tgz"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds Nuke 14 and addresses problems of Centos 7 EOL.

- Switched from Centos 7 mirrorlist to vault repositories to account for EOL of Centos 7.
- Added all versions of Nuke 14
- Removed `libmkl`  from the exclusion list, because these libraries are now required
- Regenerated [README](README.md), [config.yml](.circleci/config.yml) and [versions.json](versions.json)